### PR TITLE
Settings: fix confirm pattern crash on rotate

### DIFF
--- a/src/com/android/settings/ConfirmLockPattern.java
+++ b/src/com/android/settings/ConfirmLockPattern.java
@@ -124,6 +124,8 @@ public class ConfirmLockPattern extends SettingsActivity {
             mLockPatternView = (LockPatternView) view.findViewById(R.id.lockPattern);
             mFooterTextView = (TextView) view.findViewById(R.id.footerText);
 
+            mLockPatternView.setLockPatternUtils(mLockPatternUtils);
+
             // make it so unhandled touch events within the unlock screen go to the
             // lock pattern view.
             final LinearLayoutWithDefaultTouchRecepient topLayout


### PR DESCRIPTION
After setting a new lock pattern from settings, going right back into
"Screen lock" screen and rotating the device would cause a crash.

LockPatternView is expecting to have an instance of LockPatternUtils
available to restore its state, which is null.

Change-Id: Ib8ff83623787d431165af88e56d4a84a27340268
Signed-off-by: Roman Birg <roman@cyngn.com>