### PR TITLE
Settings: Make the Wifi regions translatable

### DIFF
--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -492,19 +492,19 @@
     </string-array>
 
     <!-- Wi-Fi settings. Presented as a list dialog to the user to choose the Wi-Fi region code. -->
-    <string-array name="wifi_countrycode_entries">
-        <item>United States</item>
-        <item>Canada, Taiwan</item>
-        <item>Germany</item>
-        <item>Europe</item>
-        <item>Japan, Russia</item>
-        <item>Australia</item>
-        <item>China</item>
-        <item>Korea</item>
-        <item>South Africa, Turkey</item>
-        <item>Israel, Singapore</item>
-        <item>Brazil</item>
-        <item>India</item>
+    <string-array name="wifi_countrycode_entries" translatable="false">
+        <item>@string/wifi_countrycode_entries_us</item>
+        <item>@string/wifi_countrycode_entries_ca</item>
+        <item>@string/wifi_countrycode_entries_de</item>
+        <item>@string/wifi_countrycode_entries_gb</item>
+        <item>@string/wifi_countrycode_entries_jp</item>
+        <item>@string/wifi_countrycode_entries_au</item>
+        <item>@string/wifi_countrycode_entries_cn</item>
+        <item>@string/wifi_countrycode_entries_kr</item>
+        <item>@string/wifi_countrycode_entries_tr</item>
+        <item>@string/wifi_countrycode_entries_sg</item>
+        <item>@string/wifi_countrycode_entries_br</item>
+        <item>@string/wifi_countrycode_entries_in</item>
     </string-array>
 
     <string-array name="wifi_countrycode_values" translatable="false">

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -1265,5 +1265,18 @@
     <string name="wifi_setting_countrycode_summary">Specify the region code for Wi\u2011Fi</string>
     <!-- Wi-Fi settings screen, error message when the frequency band could not be set [CHAR LIMIT=50]. -->
     <string name="wifi_setting_countrycode_error">There was a problem setting the region code.</string>
+    <!-- Wi-Fi region countries -->
+    <string name="wifi_countrycode_entries_us">United States</string>
+    <string name="wifi_countrycode_entries_ca">Canada, Taiwan</string>
+    <string name="wifi_countrycode_entries_de">Germany</string>
+    <string name="wifi_countrycode_entries_gb">Europe</string>
+    <string name="wifi_countrycode_entries_jp">Japan, Russia</string>
+    <string name="wifi_countrycode_entries_au">Australia</string>
+    <string name="wifi_countrycode_entries_cn">China</string>
+    <string name="wifi_countrycode_entries_kr">Korea</string>
+    <string name="wifi_countrycode_entries_tr">South Africa, Turkey</string>
+    <string name="wifi_countrycode_entries_sg">Israel, Singapore</string>
+    <string name="wifi_countrycode_entries_br">Brazil</string>
+    <string name="wifi_countrycode_entries_in">India</string>
 
 </resources>


### PR DESCRIPTION
Move the countries strings from the arrays to the strings xml,
so it can be translated in crowdin.

Change-Id: I2a64e33cfd652509218cfa88f0d633ca4766e153